### PR TITLE
Don't double quote file paths in require

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/Compile.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Compile.pm
@@ -306,7 +306,7 @@ my @warnings;
 for my $lib (@module_files)
 {
     my ($stdout, $stderr, $exit) = capture {
-        system($^X, '-Mblib', '-e', qq{require qq[$lib]});
+        system($^X, '-Mblib', '-e', qq{require q[$lib]});
     };
     is($?, 0, "$lib loaded ok");
     warn $stderr if $stderr;

--- a/t/test-compile/lib/Baz/Quz.pm
+++ b/t/test-compile/lib/Baz/Quz.pm
@@ -1,0 +1,4 @@
+package Baz::Quz;
+# ABSTRACT: Baz::Quz
+1;
+__END__


### PR DESCRIPTION
This causes problems with backslashes on Windows, e.g.:

```
perl -Mblib -e 'require qq[Foo\Bar.pm]'
# Can't locate FooBar.pm in @INC
```
