### PR TITLE
Fix test on Win32 by draining filehandle before waiting for subprocess to finish

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/Compile.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Compile.pm
@@ -332,15 +332,16 @@ my @warnings;
 for my $lib (@module_files)
 {
     # see L<perlfaq8/How can I capture STDERR from an external command?>
-    my $stdin = '';     # converted to a gensym by open3
+    open my $stdin, '<', File::Spec->devnull or die "can't open devnull: $!";
     my $stderr = IO::Handle->new;
 
     my $pid = open3($stdin, '>&STDERR', $stderr, $^X, '-Mblib', '-e', "require q[$lib]");
     binmode $stderr, ':crlf' if $^O eq 'MSWin32';
+    my @_warnings = <$stderr>;
     waitpid($pid, 0);
     is($? >> 8, 0, "$lib loaded ok");
 
-    if (my @_warnings = <$stderr>)
+    if (@_warnings)
     {
         warn @_warnings;
         push @warnings, @_warnings;


### PR DESCRIPTION
I know you have a different implementation that works, but it involves a lot more code.  I think this is a better fix.
