### PR TITLE
diag @warnings if the no-warnings test fails

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,3 @@
 # https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html
 Jérôme Quelin <jquelin@gmail.com> Jerome Quelin <jquelin@gmail.com>
+<kentnl@cpan.org> <kentfredric@gmail.com>

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+ - When warnings occur under fail_on_warning, diag them. (GH #9, Kent Fredric)
 
 2.045     2014-08-07 04:25:14Z
  - re-release to remove README.pod from shipped dist

--- a/lib/Dist/Zilla/Plugin/Test/Compile.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Compile.pm
@@ -446,7 +446,7 @@ CODE
 
 {{
 ($fail_on_warning ne 'none'
-    ? q{is(scalar(@warnings), 0, 'no warnings found')}
+    ? q{is(scalar(@warnings), 0, 'no warnings found') or diag(@warnings)}
     : '# no warning checks')
 .
 ($fail_on_warning eq 'author'


### PR DESCRIPTION
( Also Correct .mailmap for kentnl )

```
21:34:33 < leont> ether: can't Test::Compile give a little more information on what warnings were observed?
21:36:09 < leont> I have no idea how to interpret this: 
                  http://www.cpantesters.org/cpan/report/5f4248bc-27bf-11e4-9612-bdb94915a708
21:36:09 < dipsy> [ CPAN Testers Reports: Report for App-s2p-1.002 ] 
21:47:55 < kentnl> +1 , looking at the source does indeed suggest it should || diag @warnings
21:50:40 < kentnl> leont: incidentally, you're getting it due to fail_on_warning = all
```
